### PR TITLE
unsuccessful attempt at using mkernel due to licensing issues

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,6 +12,21 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+    
+      - name: Set up MATLAB
+        uses: matlab-actions/setup-matlab@v2
+        with:
+          release: R2024a
+
+      - name: Install python dependencies
+        run: |
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/hostedtoolcache/MATLAB/2024.1.999/x64/bin/glnxa64
+          pip install "matlabengine==24.1.2"
+          pip install git+https://github.com/allefeld/mkernel.git
+          pip install nbformat nbclient
    
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ Full instructions can be found at the link above, however in brief:
 * In RStudio, open `index.qmd`, above the document click `Render`
 * In the terminal, run `quarto render` to build the files, or `quarto preview` to spin up the preview server.
 
+### Running MATLAB code cells
+
+This presentation experimentally uses `mkernel` to run MATLAB code cells inside Quarto.
+
+`mkernel` depends on `matlabengine` (the MATLAB engine for python), which is fun to install.
+
+You may need to run the following commands from shell first, e.g. in Linux run the following, replacing `<matlabroot>` with the location of your MATLAB installation, e.g. `/usr/local/MATLAB/R2023a/`.
+
+```sh
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<matlabroot>/bin/glnxa64
+pip install matlabengine
+```
+
+```sh
+pip install git+https://github.com/allefeld/mkernel.git
+```
 
 ## Contributing
 Contributions and improvements are very welcome! Please fork this repo and make a pull request against the `main` branch.

--- a/index.qmd
+++ b/index.qmd
@@ -17,6 +17,7 @@ title-slide-attributes:
   data-background-image: assets/images/joshua-sortino-LqKhnDzSF-8-unsplash.jpg
 #   data-background-size: contain
   data-background-opacity: "0.2"
+jupyter: mkernel
 ---
 
 # Reproducibility{background-image="assets/images/national-cancer-institute-J28Nn-CDbII-unsplash.jpg" background-opacity="0.3"}
@@ -118,6 +119,43 @@ Possible solutions:
 :::{.notes}
 + MathWorks are working hard to integrate with open source
 :::
+
+---
+
+```{matlab}
+L = 160*membrane(1,100);
+f = figure;
+ax = axes;
+
+s = surface(L);
+s.EdgeColor = 'none';
+view(3)
+
+ax.CameraPosition = [-145.5 -229.7 283.6];
+ax.CameraTarget = [77.4 60.2 63.9];
+ax.CameraUpVector = [0 0 1];
+ax.CameraViewAngle = 36.7;
+
+l1 = light;
+l1.Position = [160 400 80];
+l1.Style = 'local';
+l1.Color = [0 0.8 0.8];
+ 
+l2 = light;
+l2.Position = [.5 -1 .4];
+l2.Color = [0.8 0.8 0];
+
+s.FaceColor = [0.9 0.2 0.2];
+
+s.FaceLighting = 'gouraud';
+s.AmbientStrength = 0.3;
+s.DiffuseStrength = 0.6; 
+s.BackFaceLighting = 'lit';
+
+s.SpecularStrength = 1;
+s.SpecularColorReflectance = 1;
+s.SpecularExponent = 7;
+```
 
 # Lessons{background-image="assets/images/pawel-czerwinski-2CX_J3qAg80-unsplash.jpg" background-color="white" background-opacity="0.3"}
 


### PR DESCRIPTION
Keeping this here for visibility of failure.

Tried to use `mkernel` to run Matlab in Quarto code cells in a GitHub action.

Apparently running Matlab engine doesn't work in Github Actions due to some licensing limitation (see https://github.com/matlab-actions/setup-matlab/issues/13).